### PR TITLE
Fixing persistent attribute value in _showTopFlash

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -318,7 +318,7 @@ class _FlashPageState extends State<FlashPage> {
     showFlash(
       context: context,
       duration: const Duration(seconds: 2),
-      persistent: false,
+      persistent: true,
       builder: (_, controller) {
         return Flash(
           controller: controller,


### PR DESCRIPTION
This attribute causes an error when it is set to false and the component is not shown. 

_AssertionError ('package:flash/flash.dart': Failed assertion: line 99 pos 14: 'overlay != rootOverlay': overlay can't be the root overlay when persistent is false)