### PR TITLE
feat: Push flash without Navigator but with Overlay

### DIFF
--- a/lib/flash.dart
+++ b/lib/flash.dart
@@ -91,8 +91,9 @@ class FlashController<T> {
     this.persistent = true,
     this.onWillPop,
   }) : route = ModalRoute.of(context) {
-    final rootOverlay = Navigator.of(context, rootNavigator: true).overlay;
-    if (persistent) {
+    final rootOverlay =
+        Navigator.maybeOf(context, rootNavigator: true)?.overlay;
+    if (persistent && rootOverlay != null) {
       overlay = rootOverlay;
     } else {
       overlay = Overlay.of(context);


### PR DESCRIPTION
It can push a flash without needing a Navigator widget in the tree but only with the Overlay widget

An example is:
```dart
MaterialApp(
      builder: (context, child) { // This context does not have a Navigator
        return wrapWithOverlay(
          builder: (context) { // But you can push the same by wrapping with Overlay widget
            context.showFlashBar(content: Text('Hola'));
            return child!;
          },
        );
      },
    );
```